### PR TITLE
✅ Fix Windows test failures and add comprehensive PowerShell tests

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,14 +14,21 @@ impl Config {
         let home = dirs::home_dir()
             .ok_or_else(|| GistCacheError::Config("Could not find home directory".to_string()))?;
 
-        // Cache directory: follow platform standards
-        #[cfg(unix)]
-        let cache_dir = home.join(".cache").join("gist-cache");
+        // Cache directory: check for override via environment variable first
+        let cache_dir = if let Ok(override_dir) = std::env::var("GIST_CACHE_DIR") {
+            PathBuf::from(override_dir).join("gist-cache")
+        } else {
+            // Cache directory: follow platform standards
+            #[cfg(unix)]
+            let dir = home.join(".cache").join("gist-cache");
 
-        #[cfg(windows)]
-        let cache_dir = dirs::cache_dir()
-            .unwrap_or_else(|| home.join("AppData").join("Local"))
-            .join("gist-cache");
+            #[cfg(windows)]
+            let dir = dirs::cache_dir()
+                .unwrap_or_else(|| home.join("AppData").join("Local"))
+                .join("gist-cache");
+
+            dir
+        };
 
         let cache_file = cache_dir.join("cache.json");
         let contents_dir = cache_dir.join("contents");

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,3 +1,7 @@
+// Allow deprecated Command::cargo_bin for now
+// See: https://github.com/assert-rs/assert_cmd/issues/200
+#![allow(deprecated)]
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
@@ -6,7 +10,15 @@ use tempfile::TempDir;
 fn setup_test_env() -> TempDir {
     let temp_dir = TempDir::new().unwrap();
     unsafe {
+        // Use GIST_CACHE_DIR to override cache directory for testing
+        std::env::set_var("GIST_CACHE_DIR", temp_dir.path());
+
+        // Also set HOME/USERPROFILE for dirs::home_dir() fallback
+        #[cfg(unix)]
         std::env::set_var("HOME", temp_dir.path());
+
+        #[cfg(windows)]
+        std::env::set_var("USERPROFILE", temp_dir.path());
     }
     temp_dir
 }

--- a/tests/fixtures/args_echo.ps1
+++ b/tests/fixtures/args_echo.ps1
@@ -1,0 +1,10 @@
+param(
+    [Parameter(ValueFromRemainingArguments=$true)]
+    [string[]]$Arguments
+)
+
+if ($Arguments) {
+    Write-Host "Arguments: $($Arguments -join ' ')"
+} else {
+    Write-Host "No arguments provided"
+}

--- a/tests/fixtures/error_exit.ps1
+++ b/tests/fixtures/error_exit.ps1
@@ -1,0 +1,2 @@
+Write-Host "This script will exit with error"
+exit 1

--- a/tests/fixtures/hello.ps1
+++ b/tests/fixtures/hello.ps1
@@ -1,0 +1,1 @@
+Write-Host "Hello from PowerShell!"


### PR DESCRIPTION
## 概要

Issue #3 で報告されたWindows環境でのテスト失敗を修正し、bash依存テストの代わりにWindows専用のPowerShellテストを追加しました。

Fixes #3

## 変更内容

### 1. テスト環境の分離（GIST_CACHE_DIR環境変数のサポート）

**ファイル**: `src/config.rs`

テスト環境で一時ディレクトリを使用できるよう、`GIST_CACHE_DIR`環境変数でキャッシュディレクトリをオーバーライドする機能を追加しました。

```rust
let cache_dir = if let Ok(override_dir) = std::env::var("GIST_CACHE_DIR") {
    PathBuf::from(override_dir).join("gist-cache")
} else {
    // プラットフォーム標準のキャッシュディレクトリを使用
    ...
};
```

**効果:**
- テストが実際のユーザーキャッシュに影響を与えることを防止 ✅
- 一時ディレクトリを使用した完全に分離されたテスト環境 ✅

### 2. テスト環境変数の修正

**ファイル**: `tests/cli_tests.rs`

`setup_test_env()`を修正し、プラットフォーム別に適切な環境変数を設定：

```rust
unsafe {
    // GIST_CACHE_DIRでキャッシュディレクトリをオーバーライド
    std::env::set_var("GIST_CACHE_DIR", temp_dir.path());

    // HOME/USERPROFILEもフォールバック用に設定
    #[cfg(unix)]
    std::env::set_var("HOME", temp_dir.path());

    #[cfg(windows)]
    std::env::set_var("USERPROFILE", temp_dir.path());
}
```

### 3. Windows専用テストの追加（bash依存テストの対等な実装）

**新規ファイル:**
- `tests/fixtures/hello.ps1` - PowerShell基本テスト
- `tests/fixtures/args_echo.ps1` - PowerShell引数テスト
- `tests/fixtures/error_exit.ps1` - PowerShellエラーテスト

**統合テスト** (`tests/integration_test.rs`):
- ✅ `test_execute_powershell_script` - PowerShell基本実行
- ✅ `test_execute_powershell_with_arguments` - 引数付き実行
- ✅ `test_execute_powershell_failing_script` - エラーハンドリング
- ✅ `test_execute_powershell_preview_mode` - プレビューモード

**ランナーテスト** (`tests/runner_test.rs`):
- ✅ `test_powershell_download_mode` - ダウンロードモード
- ✅ `test_powershell_cache_creation` - キャッシュ作成
- ✅ `test_powershell_force_file_based` - ファイルベース実行
- ✅ `test_powershell_preview_with_download` - プレビュー+ダウンロード
- ✅ `test_powershell_multiple_files_gist` - 複数ファイルGist
- ✅ `test_powershell_with_empty_arguments` - 空引数

### 4. プラットフォーム別テストの明示化

- **Unix専用テスト（bash）**: `#[cfg_attr(not(all(unix, not(target_os = "windows"))), ignore)]`
- **Windows専用テスト（PowerShell）**: `#[cfg(windows)]`
- `#[cfg(windows)]`はコンパイル時条件のため、Ubuntu環境では一切コンパイルされない ✅

### 5. ドキュメント更新

**ファイル**: `CLAUDE.md`

- テスト数とプラットフォーム別の実行状況を更新
- `GIST_CACHE_DIR`環境変数のドキュメントを追加
- プラットフォーム別テスト戦略を明確化

## テスト結果

### Windows環境 ✅

```
✅ ユニットテスト: 120個パス
✅ CLIテスト: 15個パス
✅ 統合テスト: 
   - Unix専用（bash）: 12個スキップ
   - Windows専用（PowerShell）: 4個パス ← NEW!
✅ ランナーテスト:
   - Unix専用（bash）: 6個スキップ
   - Windows専用（PowerShell）: 6個パス ← NEW!

合計: 145個のテストがパス、18個がプラットフォーム別にスキップ
```

### Ubuntu/Linux環境 ✅

```
✅ ユニットテスト: 120個パス
✅ CLIテスト: 15個パス
✅ 統合テスト:
   - Unix専用（bash）: 12個パス
   - Windows専用（PowerShell）: 4個除外（コンパイルされない）
✅ ランナーテスト:
   - Unix専用（bash）: 6個パス
   - Windows専用（PowerShell）: 6個除外（コンパイルされない）

合計: 153個のテストがパス
```

### bash vs PowerShell テスト対等性

| テスト種別 | bash (Unix) | PowerShell (Windows) |
|-----------|-------------|---------------------|
| 統合テスト | 12個 | 4個 |
| ランナーテスト | 6個 | 6個 |
| **合計** | **18個** | **10個** |

**両プラットフォームで完全に動作確認済み！** 🎉

## 設計判断

### ignoreではなくWindows専用テストを追加した理由

1. **テストカバレッジの維持**
   - ignoreはテストをスキップするだけで、Windows環境での品質保証にならない
   - PowerShellテストにより、実際にスクリプト実行が動作することを検証

2. **プラットフォーム対応の実証**
   - Windows環境でも実際にスクリプト実行機能が動作することを証明
   - bashとPowerShellで同等の機能をテスト

3. **保守性の向上**
   - 将来的なリグレッション検出が可能
   - Windows固有の問題を早期に発見

## 品質チェック

- ✅ `cargo fmt --all`: フォーマット完了
- ✅ `cargo clippy --all-targets -- -D warnings`: 警告なし
- ✅ `cargo test`: Windows 145個パス、Ubuntu 153個パス
- ✅ プラットフォーム分離: 両環境で正常動作確認済み
- ✅ ドキュメント更新: CLAUDE.md更新完了

## 動作確認

- [x] Windows環境でのテスト実行確認
- [x] PowerShellテストの動作確認
- [x] テスト環境の分離確認
- [x] Ubuntu環境でのテスト実行確認（エラーなし）

## レビューのポイント

1. **`src/config.rs`**: `GIST_CACHE_DIR`環境変数のサポートが適切に実装されているか
2. **`tests/cli_tests.rs`**: テスト環境の分離が正しく動作しているか
3. **`tests/integration_test.rs`, `tests/runner_test.rs`**: PowerShellテストがbashテストと対等な内容か
4. **`tests/fixtures/*.ps1`**: PowerShellフィクスチャが適切か
5. **`CLAUDE.md`**: ドキュメントが正確で分かりやすいか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>