### PR TITLE
✨ Add cache clean command

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ gist-cache-rs cache list
 # Check cache size
 gist-cache-rs cache size
 
+# Clean old cache entries
+gist-cache-rs cache clean --older-than 30        # Remove entries older than 30 days
+gist-cache-rs cache clean --orphaned             # Remove orphaned cache files
+gist-cache-rs cache clean --dry-run --orphaned   # Preview what would be deleted
+
 # Clear all caches
 gist-cache-rs cache clear
 ```

--- a/book/src/developer-guide/architecture.md
+++ b/book/src/developer-guide/architecture.md
@@ -19,7 +19,7 @@ The codebase follows a modular architecture with clear separation of concerns:
 ```text
 src/
 ├── cache/              # Cache management layer
-│   ├── content.rs      # Content cache (541 lines)
+│   ├── content.rs      # Content cache (1001 lines)
 │   ├── types.rs        # Data type definitions (246 lines)
 │   ├── update.rs       # Incremental update logic (849 lines)
 │   └── mod.rs
@@ -39,7 +39,7 @@ src/
 ├── lib.rs              # Library root
 └── main.rs             # Entry point
 
-Total: 16 files, approx. 4,200 lines
+Total: 16 files, approx. 4,660 lines
 ```
 
 ### Cache Module (`cache/`)
@@ -64,6 +64,11 @@ The cache layer implements a sophisticated 2-layer caching structure:
 - Manages individual Gist content files in `~/.cache/gist-cache/contents/{gist_id}/{filename}`
 - Created on-demand during first execution
 - Provides approximately 20x performance improvement for subsequent executions
+- Implements cache cleaning functionality:
+  - `clean()`: Remove old or orphaned cache entries
+  - `--older-than`: Delete entries based on Gist's `updated_at` timestamp
+  - `--orphaned`: Remove content cache files without corresponding metadata
+  - `--dry-run`: Preview deletion without actually removing files
 
 ### GitHub Module (`github/`)
 

--- a/book/src/user-guide/examples.md
+++ b/book/src/user-guide/examples.md
@@ -341,6 +341,69 @@ Total size: 89.45 KB
 Cache directory: /home/user/.cache/gist-cache/contents
 ```
 
+### Clean Old Cache Entries
+
+```bash
+# Preview what would be deleted (dry-run mode)
+$ gist-cache-rs cache clean --dry-run --older-than 30
+Clean cache entries
+
+DRY RUN MODE - No files will be deleted
+
+  Removing entries older than 30 days
+
+Would delete 3 entries:
+
+  ID: 7bcb324e9291fa350334df8efb7f0deb
+    Description: old script #bash
+    Updated: 2025-09-15 10:20:30
+
+  ID: a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6
+    Description: deprecated utility
+    Updated: 2025-09-01 08:15:22
+
+  ID: 9f8e7d6c5b4a3210fedcba9876543210
+    Description: test script
+    Updated: 2025-08-28 14:45:10
+
+Would free up: 145.23 KB
+
+# Actually delete old entries
+$ gist-cache-rs cache clean --older-than 30
+Clean cache entries
+
+  Removing entries older than 30 days
+
+Deleted 3 entries:
+
+  ID: 7bcb324e9291fa350334df8efb7f0deb
+    Description: old script #bash
+    Updated: 2025-09-15 10:20:30
+
+  ID: a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6
+    Description: deprecated utility
+    Updated: 2025-09-01 08:15:22
+
+  ID: 9f8e7d6c5b4a3210fedcba9876543210
+    Description: test script
+    Updated: 2025-08-28 14:45:10
+
+Freed up: 145.23 KB
+
+# Remove orphaned cache files (content without metadata)
+$ gist-cache-rs cache clean --orphaned
+Clean cache entries
+
+  Removing orphaned content cache files
+
+Deleted 2 entries:
+
+  ID: orphaned123456 (orphaned)
+  ID: deleted789abc (orphaned)
+
+Freed up: 23.45 KB
+```
+
 ### Clear All Caches
 
 ```bash

--- a/book/src/user-guide/quickstart.md
+++ b/book/src/user-guide/quickstart.md
@@ -128,6 +128,11 @@ gist-cache-rs cache list
 # Check cache size
 gist-cache-rs cache size
 
+# Clean old cache entries
+gist-cache-rs cache clean --older-than 30        # Remove entries older than 30 days
+gist-cache-rs cache clean --orphaned             # Remove orphaned cache files
+gist-cache-rs cache clean --dry-run --orphaned   # Preview what would be deleted
+
 # Clear all caches
 gist-cache-rs cache clear
 ```

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -2,6 +2,6 @@ pub mod content;
 pub mod types;
 pub mod update;
 
-pub use content::ContentCache;
+pub use content::{CleanOptions, CleanResult, ContentCache};
 pub use types::{GistCache, GistFile, GistInfo};
 pub use update::CacheUpdater;


### PR DESCRIPTION
## 概要

Closes #24

古いキャッシュエントリや孤立したコンテンツキャッシュを削除する `cache clean` コマンドを実装しました。

## 機能

### コマンドオプション

- `--older-than <DAYS>`: 指定日数より古いエントリを削除（Gistの `updated_at` を基準）
- `--orphaned`: メタデータに存在しない孤立したコンテンツキャッシュを削除
- `--dry-run`: 実際には削除せず、削除対象をプレビュー

### 使用例

```bash
# 30日より古いエントリを削除
gist-cache-rs cache clean --older-than 30

# 孤立したキャッシュファイルを削除
gist-cache-rs cache clean --orphaned

# ドライラン（プレビューのみ）
gist-cache-rs cache clean --dry-run --older-than 30

# 両方の条件を指定
gist-cache-rs cache clean --older-than 30 --orphaned
```

## 実装内容

### コード変更

- **src/cache/content.rs** (541→1001行)
  - `clean()`: メインクリーニングロジック
  - `should_delete_gist()`: 削除条件チェック
  - `calculate_dir_size()`: ディレクトリサイズ計算
  - `CleanOptions`/`CleanResult`: データ構造
- **src/cli.rs**
  - `CleanArgs` 構造体を追加
  - `CacheCommands::Clean` ハンドラを実装
  - 削除対象の詳細表示（ID、説明、更新日時、サイズ）
- **src/cache/mod.rs**
  - `CleanOptions` と `CleanResult` をエクスポート

### テスト

10個の包括的なテストを追加：

**content.rs のテスト:**
- `test_clean_with_older_than`: 古いエントリの削除
- `test_clean_with_orphaned`: 孤立エントリの削除
- `test_clean_with_dry_run`: ドライランモード
- `test_clean_with_no_criteria`: 条件なしの場合
- `test_clean_with_both_criteria`: 両方の条件を指定
- `test_clean_when_nothing_matches`: マッチなしの場合
- `test_calculate_dir_size`: サイズ計算

**cli.rs のテスト:**
- `test_handle_cache_command_clean_no_cache`: キャッシュなしエラー
- `test_handle_cache_command_clean_no_criteria`: 条件なしの処理
- `test_handle_cache_command_clean_with_orphaned`: 孤立エントリ削除

### テスト結果

```
✅ 全154テストが成功
   - 129 ユニットテスト
   - 15 CLI統合テスト
   - 4 PowerShell実行テスト
   - 6 追加統合テスト
```

**機能デグレードなし**: 既存の全テストが引き続きパスしています。

## ドキュメント更新

- `README.md`: Cache Managementセクションに使用例を追加
- `book/src/user-guide/quickstart.md`: 基本的な使い方を追加
- `book/src/user-guide/examples.md`: 詳細な使用例を追加
- `book/src/developer-guide/architecture.md`: アーキテクチャ説明を更新

## チェックリスト

- [x] 機能実装完了
- [x] テスト追加（10個の新規テスト）
- [x] 全テスト成功（154テスト）
- [x] ドキュメント更新
- [x] コードフォーマット（cargo fmt）
- [x] Lintチェック（cargo clippy）

## レビューポイント

1. **削除基準**: `updated_at`（Gistの最終更新日時）を基準に削除判定していますが、これで問題ないでしょうか？
2. **エラーハンドリング**: 削除中にエラーが発生した場合、処理を継続します。
3. **出力フォーマット**: 削除対象の詳細表示が適切かご確認ください。