### PR TITLE
Improve interactive selection with arrow-key navigation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ chrono = {version = "0.4", features = ["serde"]}
 clap = {version = "4.5", features = ["derive"]}
 clap_complete = "4.5"
 colored = "3.0"
+dialoguer = "0.12"
 dirs = "6.0"
 indicatif = "0.18"
 serde = {version = "1.0", features = ["derive"]}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A high-performance CLI tool written in Rust for efficiently caching, searching, 
 - 📥 **Easy Downloads**: Save Gist files to your download folder
 - 🗂️ **Cache Management**: Powerful cache inspection and maintenance
 - 📊 **Progress Display**: Visual feedback with progress bars and spinners
+- 🎯 **Interactive Selection**: Intuitive arrow-key navigation for selecting Gists
 
 **Supported Platforms**: Linux, macOS, Windows 10 or later
 


### PR DESCRIPTION
## Summary

Improve Gist selection UX by replacing number input with interactive arrow-key navigation.

Closes #30

## Features

- ⬆️⬇️ **Arrow-key navigation**: Use ↑/↓ keys to navigate through Gist options
- 🎨 **Visual selection**: ColorfulTheme for better visual presentation
- ⎋ **Esc to cancel**: Support Esc key to cancel selection
- 📋 **Improved display**: Better format showing "description - files"

## Implementation Details

- Added `dialoguer = "0.12"` dependency for interactive CLI prompts
- Refactored `select_from_results` in `src/search/query.rs`:
  - Replaced manual number input with `dialoguer::Select`
  - Used `interact_opt()` to support cancellation with Esc key
  - Applied `ColorfulTheme` for visual enhancement
  - Improved display format: "description - files"

## Changes

**Code:**
- `Cargo.toml`: Add dialoguer = "0.12"
- `src/search/query.rs`: Refactor select_from_results function (22 lines changed)
- `README.md`: Add Interactive Selection to features list

**Tests:**
- ✅ All 138 unit tests passing
- ✅ All 25 integration tests passing
- ✅ No feature degradation

## User Experience

### Before (Number Input)
```
Multiple Gists found:

 1. Rust script | main.rs
 2. Python script | main.py
 3. Backup script | backup.sh

Select a number (1-3): _
```

### After (Arrow-key Navigation)
```
Multiple Gists found:

? Select a Gist
  > Rust script - main.rs
    Python script - main.py
    Backup script - backup.sh

[↑/↓: Navigate | Enter: Select | Esc: Cancel]
```

## Benefits

- **Better UX**: Intuitive navigation with immediate visual feedback
- **Error prevention**: No need to type numbers, reducing input errors
- **Cancellation**: Easy to cancel with Esc key
- **Professional feel**: Modern CLI experience with arrow-key navigation

## Related

- Feature plan: [2.3 Interactive Selection Improvement](https://7rikazhexde.github.io/gist-cache-rs/)
- Branch: `feature/interactive-selection-improvement`
- Commit: c8b1a2c

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>