### PR TITLE
Add JSON output format option for cache list command

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -23,6 +23,8 @@
   "MD033": false,
   // MD034: Bare URL used - disable (allow bare URLs)
   "MD034": false,
+  // MD040: Fenced code blocks should have a language specified - disable
+  "MD040": false,
   // MD041: First line in file should be a top level heading - disable
   "MD041": false,
   // MD060: Table column style - enforce aligned style

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,7 +1,0 @@
-{
-  "default": true,
-  "MD025": {
-    "siblings_only": true
-  },
-  "MD040": false
-}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A high-performance CLI tool written in Rust for efficiently caching, searching, 
 - 🗂️ **Cache Management**: Powerful cache inspection and maintenance
 - 📊 **Progress Display**: Visual feedback with progress bars and spinners
 - 🎯 **Interactive Selection**: Intuitive arrow-key navigation for selecting Gists
+- 📋 **Output Format Options**: JSON output for scripting and automation
 
 **Supported Platforms**: Linux, macOS, Windows 10 or later
 
@@ -131,8 +132,14 @@ cargo install --path .
 ## Cache Management
 
 ```bash
-# List cached Gists
+# List cached Gists (human-readable format)
 gist-cache-rs cache list
+
+# List cached Gists in JSON format (for scripting)
+gist-cache-rs cache list --format json
+
+# Filter with jq (requires jq installed)
+gist-cache-rs cache list --format json | jq '.[] | select(.description | contains("backup"))'
 
 # Check cache size
 gist-cache-rs cache size

--- a/book/src/user-guide/examples.md
+++ b/book/src/user-guide/examples.md
@@ -330,6 +330,58 @@ ID: e3a6336c9f3476342626551372f14d6e
 Total: 2 Gists cached
 ```
 
+### List Cache in JSON Format
+
+```bash
+# Output in JSON format for scripting
+$ gist-cache-rs cache list --format json
+[
+  {
+    "id": "7bcb324e9291fa350334df8efb7f0deb",
+    "description": "hello_args.sh - Argument display script #bash #test",
+    "files": [
+      "hello_args.sh"
+    ],
+    "updated_at": "2025-10-26T12:30:45+09:00"
+  },
+  {
+    "id": "e3a6336c9f3476342626551372f14d6e",
+    "description": "data_analysis.py - Pandas/NumPy usage example #python #pep723",
+    "files": [
+      "data_analysis.py"
+    ],
+    "updated_at": "2025-10-25T18:22:10+09:00"
+  }
+]
+
+# Filter with jq (requires jq installed)
+$ gist-cache-rs cache list --format json | jq '.[] | select(.description | contains("python"))'
+{
+  "id": "e3a6336c9f3476342626551372f14d6e",
+  "description": "data_analysis.py - Pandas/NumPy usage example #python #pep723",
+  "files": [
+    "data_analysis.py"
+  ],
+  "updated_at": "2025-10-25T18:22:10+09:00"
+}
+
+# Extract only IDs
+$ gist-cache-rs cache list --format json | jq -r '.[].id'
+7bcb324e9291fa350334df8efb7f0deb
+e3a6336c9f3476342626551372f14d6e
+
+# Count Gists by tag
+$ gist-cache-rs cache list --format json | jq '[.[] | select(.description | contains("#bash"))] | length'
+1
+```
+
+**Key Points:**
+
+- 📋 Use `--format json` to output machine-readable JSON
+- 🔧 Perfect for scripting and automation tasks
+- 🎯 Combine with `jq` for powerful filtering and data extraction
+- 📊 JSON output includes: id, description, files array, and updated_at timestamp
+
 ### Check Cache Size
 
 ```bash


### PR DESCRIPTION
## Summary

Adds JSON output format option to the `cache list` command to enable scripting and automation use cases.

Fixes #32

## Changes

- ✨ Add `OutputFormat` enum (`Text`, `Json`) to CLI
- 🔧 Modify `CacheCommands::List` to accept `ListArgs` with `--format` flag
- 📋 Implement `GistListItem` struct for JSON serialization
- 🎯 Add dual-format output in `handle_cache_command()`
- ✅ Add 2 integration tests for JSON format (`test_cache_list_json_format_empty`, `test_cache_list_json_format`)
- 📚 Update README.md and examples.md documentation with JSON usage examples

## Example Usage

```bash
# Human-readable text output (default)
gist-cache-rs cache list

# JSON output for scripting
gist-cache-rs cache list --format json

# Filter with jq
gist-cache-rs cache list --format json | jq '.[] | select(.description | contains("backup"))'
```

## Test Results

All 170 tests passing:
- 133 unit tests
- 27 integration tests
- 10 execution tests

```bash
cargo test
test result: ok. 170 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Documentation

- Updated README.md with JSON output format feature and examples
- Updated book/src/user-guide/examples.md with comprehensive JSON usage examples including jq integration

## Test plan

- [x] All existing tests pass
- [x] New tests added for JSON format (empty and populated)
- [x] Backward compatibility maintained (text is default)
- [x] Documentation updated
- [x] No feature degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)