### PR TITLE
feat(cli): ✨ enable tab completion for config subcommand

### DIFF
--- a/book/src/user-guide/shell-completions.md
+++ b/book/src/user-guide/shell-completions.md
@@ -95,20 +95,26 @@ Copy-Item "$PROFILE.backup" $PROFILE
 
 **Linux / macOS:**
 
-```bash
-# Generate and install completion script
-gist-cache-rs completions bash > ~/.local/share/bash-completion/completions/gist-cache-rs
+1. **Generate Completion Script:**
+    Create the directory for completions and generate the script.
 
-# If the directory doesn't exist, create it first
-mkdir -p ~/.local/share/bash-completion/completions
-gist-cache-rs completions bash > ~/.local/share/bash-completion/completions/gist-cache-rs
-```
+    ```bash
+    # Create the directory if it doesn't exist
+    mkdir -p ~/.local/share/bash-completion/completions
 
-If completions don't load automatically, add this to your `~/.bashrc`:
+    # Generate and install the completion script
+    gist-cache-rs completions bash > ~/.local/share/bash-completion/completions/gist-cache-rs
+    ```
 
-```bash
-source ~/.local/share/bash-completion/completions/gist-cache-rs
-```
+2. **Activate Completions:**
+    The `bash-completion` package should automatically load the script. If completions do not work after **starting a new shell session**, you may need to source it manually in your `~/.bashrc`.
+
+    ```bash
+    # Add this line to ~/.bashrc if completions are not loading
+    echo 'source ~/.local/share/bash-completion/completions/gist-cache-rs' >> ~/.bashrc
+    ```
+
+    To apply the change immediately, run `source ~/.bashrc`.
 
 **Windows (Git Bash):**
 
@@ -155,27 +161,59 @@ source ~/.zshrc
 
 **Linux / macOS:**
 
+Fish automatically loads completion scripts from its completions directory.
+
 ```bash
-# Fish automatically loads completions from this directory
+# Generate and place the completion script
 gist-cache-rs completions fish > ~/.config/fish/completions/gist-cache-rs.fish
 ```
 
-No additional configuration needed. Fish will automatically load the completion script.
+The changes will take effect when you start a new Fish session. No additional configuration is needed.
 
 ### PowerShell
 
 **Windows:**
 
-```powershell
-# Create scripts directory if it doesn't exist
-New-Item -ItemType Directory -Force -Path ~\Documents\PowerShell\Scripts
+1. **Generate Completion Script:**
+    First, ensure the target directory exists and then generate the script.
 
-# Generate completion script
-gist-cache-rs completions powershell > ~\Documents\PowerShell\Scripts\gist-cache-rs.ps1
+    ```powershell
+    # Create a directory for PowerShell scripts if it doesn't exist
+    $scriptDir = ~\Documents\PowerShell\Scripts
+    if (-not (Test-Path $scriptDir)) {
+        New-Item -ItemType Directory -Force -Path $scriptDir
+    }
 
-# Add to PowerShell profile
-Add-Content $PROFILE "`n. ~\Documents\PowerShell\Scripts\gist-cache-rs.ps1"
-```
+    # Generate the completion script
+    gist-cache-rs completions powershell > $scriptDir\gist-cache-rs.ps1
+    ```
+
+2. **Update PowerShell Profile:**
+    Next, add the script to your PowerShell profile to have it load automatically.
+
+    ```powershell
+    # Create the profile if it doesn't exist
+    if (-not (Test-Path $PROFILE)) {
+        New-Item -Path $PROFILE -ItemType File -Force
+    }
+
+    # Add the script loading command to your profile
+    Add-Content $PROFILE "`n. $scriptDir\gist-cache-rs.ps1"
+    ```
+
+3. **Activate Completions:**
+    The changes will take effect when you start a new PowerShell session. To apply them immediately in your current session, run:
+
+    ```powershell
+    . $PROFILE
+    ```
+
+    **Note on Execution Policy:** If you encounter an error, your script execution policy might be too restrictive. You can check it with `Get-ExecutionPolicy`. If it's `Restricted`, you may need to change it. For example:
+
+    ```powershell
+    # This allows locally created scripts to run
+    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+    ```
 
 **Linux / macOS (PowerShell Core):**
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,20 +43,26 @@ pub struct ConfigArgs {
     pub command: ConfigCommands,
 }
 
+#[derive(Args)]
+pub struct SetConfigArgs {
+    /// Configuration key (e.g., defaults.interpreter)
+    pub key: String,
+    /// Configuration value
+    pub value: String,
+}
+
+#[derive(Args)]
+pub struct GetConfigArgs {
+    /// Configuration key
+    pub key: String,
+}
+
 #[derive(Subcommand)]
 pub enum ConfigCommands {
     /// Set a configuration value
-    Set {
-        /// Configuration key (e.g., defaults.interpreter)
-        key: String,
-        /// Configuration value
-        value: String,
-    },
+    Set(SetConfigArgs),
     /// Get a configuration value
-    Get {
-        /// Configuration key
-        key: String,
-    },
+    Get(GetConfigArgs),
     /// Show all configuration values
     Show,
     /// Edit configuration file in $EDITOR
@@ -743,13 +749,19 @@ pub fn handle_config_command(mut config: Config, args: ConfigArgs) -> Result<()>
     use colored::Colorize;
 
     match args.command {
-        ConfigCommands::Set { key, value } => {
-            config.set_config_value(&key, &value)?;
-            println!("{}", format!("✓ Set {} = {}", key, value).green());
+        ConfigCommands::Set(set_args) => {
+            config.set_config_value(&set_args.key, &set_args.value)?;
+            println!(
+                "{}",
+                format!("✓ Set {} = {}", set_args.key, set_args.value).green()
+            );
         }
-        ConfigCommands::Get { key } => match config.get_config_value(&key) {
+        ConfigCommands::Get(get_args) => match config.get_config_value(&get_args.key) {
             Some(value) => println!("{}", value),
-            None => println!("{}", format!("Config key '{}' not set", key).yellow()),
+            None => println!(
+                "{}",
+                format!("Config key '{}' not set", get_args.key).yellow()
+            ),
         },
         ConfigCommands::Show => {
             println!("{}", "Configuration:".bold());


### PR DESCRIPTION
Refactor clap Subcommand enum for ConfigCommands to use Args structs instead of inline fields. This fixes an issue where tab completion for config subcommands (set, get, show, etc.) was not being generated correctly.\n\nAdditionally, the shell completion documentation for PowerShell, Bash, and Fish has been clarified to emphasize the need to start a new shell session or reload the profile to activate the completions, addressing a common point of user confusion.\n\nCloses #36