### PR TITLE
Add interactive Gist picker with preview, search, and filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Interactive Gist Selection and Preview Overhaul** (Closes #74)
+  - Selection list items are now deduplicated (no more repeated filename when it's already part of the description) and truncated to a readable width, with `Tab` to toggle full/short display
+  - `Space` opens an in-picker, syntax-highlighted content preview without leaving the list — no re-selection/re-fetch needed to look again
+  - Preview viewer shows line numbers and a cursor indicator, scrolls with `↑`/`↓`/`PageUp`/`PageDown`/`Home`/`End`, and keeps the description and current file's header pinned at the top while the body scrolls
+  - `/` filters the selection list (regex supported, falls back to literal substring matching for invalid patterns)
+  - `/` inside the preview viewer searches the file content, jumping to matches; `n`/`N` repeat the search forward/backward
+  - `--preview` output is now syntax-highlighted
+  - The picker now runs inside the terminal's alternate screen buffer, so it never leaves redraw artifacts in the shell's scrollback
+
 ## [0.8.7] - 2025-12-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ src/
    - Command-line argument → Shebang → User config → Filename heuristics → Content analysis → Fallback
 5. **Flexible Configuration**: Extension-based interpreter mapping with wildcard fallback support
 6. **Shell Completions**: Auto-generated completions for Bash, Zsh, Fish, PowerShell
-7. **Interactive UI**: Progress bars, spinners, and arrow-key navigation using `indicatif` and `dialoguer`
+7. **Interactive UI**: Progress bars/spinners (`indicatif`), configuration prompts (`dialoguer`), and a custom `console`-based Gist picker (alternate-screen buffer, `/` regex filter, `Space` syntax-highlighted preview with its own `/` search)
 8. **Platform-Specific Paths**: Conditional compilation for Unix/Windows compatibility
 
 ## Important Notes
@@ -154,7 +154,7 @@ src/
 - Cache path overridable via `GIST_CACHE_DIR` environment variable (for testing)
 - Config path also follows `GIST_CACHE_DIR` override for testing isolation
 - Tests use `MockGitHubClient` for isolation
-- Current test count: 148 tests
+- Current test count: 185 tests
 - Configuration stored in platform-specific locations:
   - Unix: `~/.config/gist-cache/config.toml`
   - Windows: `%APPDATA%\gist-cache\config.toml`
@@ -203,12 +203,13 @@ GitHub Actions automatically builds releases for:
 
 - Core: tokio, serde, anyhow, thiserror
 - CLI: clap (v4.5), clap_complete (v4.5), colored (v3.0)
-- UI: dialoguer (v0.12), indicatif (v0.18)
-- Utils: chrono (v0.4), dirs (v6.0), toml (v0.9), tokei (v13.0)
+- UI: dialoguer (v0.12), indicatif (v0.18), console (v0.16)
+- Search/preview: fancy-regex (v0.16), syntect (v5.3), two-face (v0.5)
+- Utils: chrono (v0.4), dirs (v6.0), toml (v1.0), tokei (v14.0)
 
 **Development**:
 
-- Testing: mockall (v0.14), assert_cmd (v2.0), predicates (v3.1), serial_test (v3.0)
+- Testing: mockall (v0.15), assert_cmd (v2.0), predicates (v3.1), serial_test (v4.0)
 - Utils: tempfile (v3.8)
 
 For detailed information, always refer to the [full documentation](https://7rikazhexde.github.io/gist-cache-rs/).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,19 @@ chrono = {version = "0.4", features = ["serde"]}
 clap = {version = "4.5", features = ["derive"]}
 clap_complete = "4.5"
 colored = "3.0"
+console = "0.16"
 dialoguer = "0.12"
 dirs = "6.0"
+fancy-regex = "0.16"
 indicatif = "0.18"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
+syntect = {version = "5.3", default-features = false, features = ["default-fancy"]}
 thiserror = "2.0"
 tokei = "14.0.0"
 tokio = {version = "1.35", features = ["full"]}
 toml = "1.0"
+two-face = {version = "0.5", default-features = false, features = ["syntect-fancy"]}
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/book/src/test-specs/test-set-02-search.md
+++ b/book/src/test-specs/test-set-02-search.md
@@ -34,7 +34,7 @@ To confirm that the gist-cache-rs search functionality operates correctly as des
 
 1. Search by keyword "hello": `gist-cache-rs run hello bash`
 2. Check search results.
-3. If multiple candidates are displayed, select a number and execute.
+3. If multiple candidates are displayed, highlight one with `↑`/`↓` and press `Enter` to execute.
 
 **Expected Result**:
 
@@ -135,7 +135,7 @@ To confirm that the gist-cache-rs search functionality operates correctly as des
 
 ### TC5: Selection from Multiple Candidates
 
-**Objective**: Confirm that the UI for selecting by number from multiple search results works correctly.
+**Objective**: Confirm that the interactive picker for selecting from multiple search results works correctly.
 
 **Prerequisites**:
 
@@ -144,22 +144,24 @@ To confirm that the gist-cache-rs search functionality operates correctly as des
 **Steps**:
 
 1. Search with a keyword that hits multiple results: `gist-cache-rs run hello bash`
-2. Check the displayed candidate list.
-3. Select a number (e.g., enter 4 and press Enter).
+2. Check the displayed candidate list (description/filename, deduplicated and truncated to fit the terminal).
+3. Move the highlight with `↑`/`↓` (e.g., down to the 4th item) and press `Enter`.
 4. Confirm that the selected Gist is executed.
 
 **Expected Result**:
 
-- Multiple Gists are displayed in a numbered list.
-- Description and filename of each Gist are displayed.
-- "Select a number (1-N):" prompt is displayed.
-- Gist corresponding to the entered number is executed.
+- Multiple Gists are displayed in a scrollable, arrow-key-navigable list running in the terminal's alternate screen buffer.
+- Description and filename of each Gist are displayed (long entries truncated by default; `Tab` toggles full display).
+- A footer shows the current position (`[n/total]`) and full/short state.
+- Gist corresponding to the highlighted item is executed after `Enter`.
 
 **Verification Items**:
 
-- Numbered list is displayed correctly.
-- Entering a valid number executes the corresponding Gist.
-- Error handling for invalid numbers (0, out of range, string, etc.).
+- List is displayed correctly and scrolls to keep the selection visible when there are more results than fit on screen.
+- `↑`/`↓` moves the highlight; `Enter` executes the highlighted Gist.
+- `Tab` toggles full/short item display.
+- `Space` opens a syntax-highlighted content preview of the highlighted Gist without leaving the list.
+- `/` filters the list (regex supported, falls back to literal substring matching); `Esc` clears the filter or cancels the picker.
 
 ---
 

--- a/book/src/test-specs/test-set-04-preview.md
+++ b/book/src/test-specs/test-set-04-preview.md
@@ -32,25 +32,26 @@ To confirm that the gist-cache-rs preview function (`-p`/`--preview`) works corr
 **Steps**:
 
 1. Search with `-p` option: `gist-cache-rs run -p hello bash`
-2. Select one from multiple candidates (e.g., number 7).
+2. Move the highlight to one of the candidates with `↑`/`↓` (e.g., the 7th item) and press `Enter`.
 3. Check displayed content.
 
 **Expected Result**:
 
-- Multiple Gists are displayed in a numbered list.
-- After selecting a number, the following are displayed:
+- Multiple Gists are displayed in an arrow-key-navigable list.
+- After pressing `Enter` on a highlighted item, the following are displayed:
   - Description
   - Files
   - `=== Gist Content ===` section
   - `--- Filename ---` header
-  - File content (source code)
+  - File content (source code), syntax-highlighted
 - Script is not executed (no version information or argument display).
 
 **Verification Items**:
 
 - Preview mode launches correctly.
-- Gist content is displayed correctly.
+- Gist content is displayed correctly with syntax highlighting.
 - Exits without executing.
+- (Optional) Pressing `Space` on a highlighted item before `Enter` opens the same content in an in-picker preview viewer, without exiting the list.
 
 ---
 

--- a/book/src/user-guide/examples.md
+++ b/book/src/user-guide/examples.md
@@ -72,27 +72,31 @@ show_usage() {
 $ gist-cache-rs run -p create
 Multiple Gists found:
 
-? Select a Gist
-  > A script to create 100 folders with sequential numbers (start number to end number) in a specified path. #bash | create_folders.sh
-    Create GitHub Gist with CLI | create_gist.sh
-    Create multiple directories | create_dirs.sh
-    Create backup archive | create_backup.sh
-    Create project template | create_template.sh
-    Create Docker container | create_container.sh
-    Create test data | create_testdata.py
-  [↑↓ to move, enter to select, type to filter]
+? Select a Gist (↑/↓ move, Space preview, Tab full/short, / filter, Enter select, Esc cancel)
+Filter: (press / to narrow results)
+❯ A script to create 100 folders with sequential numbers (start number to end number) in a spe...
+  Create GitHub Gist with CLI - create_gist.sh
+  Create multiple directories - create_dirs.sh
+  Create backup archive - create_backup.sh
+  Create project template - create_template.sh
+  Create Docker container - create_container.sh
+  Create test data - create_testdata.py
+  [1/7] (Tab: short)
+✔ Select a Gist · A script to create 100 folders with sequential numbers (start number to end number) in a specified path. #bash - create_folders.sh
 
 Description: A script to create 100 folders with sequential numbers (start number to end number) in a specified path. #bash
 Files: create_folders.sh
-# ... (content displayed)
+# ... (content displayed, syntax-highlighted)
 ```
 
 **Key Points:**
 
 - 🖱️ Use **arrow keys** (↑↓) to navigate between options
 - ⌨️ Press **Enter** to select the highlighted item
-- 🔍 **Type** to filter the list in real-time
-- ❌ Press **Esc** or **Ctrl+C** to cancel
+- 📏 Press **Tab** to toggle between the truncated and full item text (long entries are shortened by default)
+- 👁️ Press **Space** to open a full-screen, syntax-highlighted preview of the highlighted Gist without leaving the list
+- 🔍 Press **/** to filter the list live (regex supported, falls back to a literal substring match)
+- ❌ Press **Esc** to clear an active filter, or to cancel the picker if no filter is active (**Ctrl+C** always cancels)
 
 #### Execute in interactive mode
 
@@ -156,10 +160,12 @@ Processing completed.
 $ gist-cache-rs run -p '#pep723'
 Multiple Gists found:
 
-? Select a Gist
-  > data_analysis.py - Pandas/NumPy usage example #python #pandas #numpy #uv #pep723 #csv | data_analysis.py
-    uv_test.py - UV temporary installation test #python #pandas #numpy #uv #pep723 | uv_test.py
-  [↑↓ to move, enter to select]
+? Select a Gist (↑/↓ move, Space preview, Tab full/short, / filter, Enter select, Esc cancel)
+Filter: (press / to narrow results)
+❯ data_analysis.py - Pandas/NumPy usage example #python #pandas #numpy #uv #pep723 #csv
+  uv_test.py - UV temporary installation test #python #pandas #numpy #uv #pep723
+  [1/2] (Tab: short)
+✔ Select a Gist · data_analysis.py - Pandas/NumPy usage example #python #pandas #numpy #uv #pep723 #csv
 
 Description: data_analysis.py - Pandas/NumPy usage example #python #pandas #numpy #uv #pep723 #csv
 Files: data_analysis.py
@@ -221,10 +227,12 @@ if __name__ == "__main__":
 $ gist-cache-rs run 723 uv sample/input.csv
 Multiple Gists found:
 
-? Select a Gist
-  > data_analysis.py - Pandas/NumPy usage example #python #pandas #numpy #uv #pep723 #csv | data_analysis.py
-    uv_test.py - UV temporary installation test #python #pandas #numpy #uv #pep723 | uv_test.py
-  [↑↓ to move, enter to select]
+? Select a Gist (↑/↓ move, Space preview, Tab full/short, / filter, Enter select, Esc cancel)
+Filter: (press / to narrow results)
+❯ data_analysis.py - Pandas/NumPy usage example #python #pandas #numpy #uv #pep723 #csv
+  uv_test.py - UV temporary installation test #python #pandas #numpy #uv #pep723
+  [1/2] (Tab: short)
+✔ Select a Gist · data_analysis.py - Pandas/NumPy usage example #python #pandas #numpy #uv #pep723 #csv
 
 Description: data_analysis.py - Pandas/NumPy usage example #python #pandas #numpy #uv #pep723 #csv
 Files: data_analysis.py

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -322,7 +322,7 @@ pub fn run_gist(config: Config, args: RunArgs) -> Result<()> {
         );
         results[0]
     } else {
-        search::select_from_results(&results)?
+        search::select_from_results(&results, &config.contents_dir)?
     };
 
     let mut script_args = args.script_args;

--- a/src/execution/highlight.rs
+++ b/src/execution/highlight.rs
@@ -1,0 +1,103 @@
+use std::sync::LazyLock;
+use syntect::easy::HighlightLines;
+use syntect::highlighting::{Theme, ThemeSet};
+use syntect::parsing::{SyntaxReference, SyntaxSet};
+use syntect::util::{LinesWithEndings, as_24_bit_terminal_escaped};
+
+// syntect's bundled defaults are missing several languages this project
+// supports (TypeScript, TOML, ...); two-face ships bat's much larger
+// syntax collection instead.
+static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(two_face::syntax::extra_newlines);
+
+static THEME: LazyLock<Theme> = LazyLock::new(|| {
+    let mut themes = ThemeSet::load_defaults();
+    themes
+        .themes
+        .remove("base16-ocean.dark")
+        .expect("bundled base16-ocean.dark theme should exist")
+});
+
+/// Resolves a syntax by file extension, falling back to shebang-line
+/// detection (using in-memory `content`, not disk I/O) and finally to
+/// plain text when nothing matches.
+fn syntax_for(filename: &str, content: &str) -> &'static SyntaxReference {
+    let ext = std::path::Path::new(filename)
+        .extension()
+        .and_then(|e| e.to_str());
+
+    if let Some(ext) = ext
+        && let Some(syntax) = SYNTAX_SET.find_syntax_by_extension(ext)
+    {
+        return syntax;
+    }
+
+    SYNTAX_SET
+        .find_syntax_by_first_line(content)
+        .unwrap_or_else(|| SYNTAX_SET.find_syntax_plain_text())
+}
+
+/// Renders `content` as ANSI 24-bit colored text, using syntax rules
+/// inferred from `filename`'s extension. Falls back to the plain-text
+/// syntax (no highlighting) when the extension isn't recognized.
+pub fn highlight_content(filename: &str, content: &str) -> String {
+    let syntax = syntax_for(filename, content);
+    let mut highlighter = HighlightLines::new(syntax, &THEME);
+    let mut out = String::with_capacity(content.len() + 16);
+
+    for line in LinesWithEndings::from(content) {
+        match highlighter.highlight_line(line, &SYNTAX_SET) {
+            Ok(ranges) => out.push_str(&as_24_bit_terminal_escaped(&ranges[..], false)),
+            Err(_) => out.push_str(line),
+        }
+    }
+    out.push_str("\x1b[0m");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn highlight_content_wraps_output_in_reset_code() {
+        let result = highlight_content("script.py", "print(\"hi\")\n");
+        assert!(result.ends_with("\x1b[0m"));
+        assert!(result.contains("print"));
+    }
+
+    #[test]
+    fn highlight_content_falls_back_for_unknown_extension() {
+        let result = highlight_content("file.unknownext", "plain text content\n");
+        assert!(result.contains("plain text content"));
+        assert!(result.ends_with("\x1b[0m"));
+    }
+
+    #[test]
+    fn highlight_content_handles_empty_content() {
+        let result = highlight_content("script.sh", "");
+        assert_eq!(result, "\x1b[0m");
+    }
+
+    #[test]
+    fn syntax_for_resolves_known_extensions() {
+        assert_eq!(syntax_for("main.rs", "").name, "Rust");
+        assert_eq!(syntax_for("script.py", "").name, "Python");
+        assert_eq!(syntax_for("script.ts", "").name, "TypeScript");
+        assert_eq!(syntax_for("Cargo.toml", "").name, "TOML");
+    }
+
+    #[test]
+    fn syntax_for_falls_back_to_shebang_when_extension_unknown() {
+        let syntax = syntax_for("hello", "#!/usr/bin/env python3\nprint(1)\n");
+        assert_eq!(syntax.name, "Python");
+    }
+
+    #[test]
+    fn syntax_for_does_not_touch_disk_for_nonexistent_files() {
+        // Regression test: find_syntax_for_file() opens the path from disk
+        // to sniff the shebang, which fails for in-memory-only content.
+        // syntax_for() must resolve purely from the filename + content.
+        let syntax = syntax_for("does-not-exist-on-disk.py", "print(1)\n");
+        assert_eq!(syntax.name, "Python");
+    }
+}

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -1,3 +1,4 @@
+pub mod highlight;
 pub mod runner;
 
 pub use runner::{RunOptions, ScriptRunner};

--- a/src/execution/runner.rs
+++ b/src/execution/runner.rs
@@ -2,6 +2,7 @@ use crate::cache::ContentCache;
 use crate::cache::types::GistInfo;
 use crate::config::Config;
 use crate::error::{GistCacheError, Result};
+use crate::execution::highlight::highlight_content;
 use crate::github::GitHubApi;
 use colored::Colorize;
 use std::fs;
@@ -97,6 +98,8 @@ impl ScriptRunner {
     fn preview_content(&self) -> Result<()> {
         println!("{}", "=== Gist Content ===".cyan().bold());
 
+        let colorize = console::Term::stdout().features().colors_supported();
+
         for file in &self.gist.files {
             println!("\n{}", format!("--- {} ---", file.filename).yellow().bold());
 
@@ -117,7 +120,11 @@ impl ScriptRunner {
                 GitHubApi::new().fetch_gist_content(&self.gist.id, &file.filename)?
             };
 
-            println!("{}", content);
+            if colorize {
+                println!("{}", highlight_content(&file.filename, &content));
+            } else {
+                println!("{}", content);
+            }
         }
 
         Ok(())

--- a/src/search/interactive.rs
+++ b/src/search/interactive.rs
@@ -1,0 +1,1019 @@
+use crate::cache::ContentCache;
+use crate::cache::types::GistInfo;
+use crate::error::{GistCacheError, Result};
+use crate::execution::highlight::highlight_content;
+use crate::github::GitHubApi;
+use console::{Key, Term, style};
+use std::collections::HashMap;
+use std::path::Path;
+
+const DEFAULT_DESCRIPTION: &str = "No description";
+// Reserve space for the "❯ "/"  " cursor prefix and a trailing column so a
+// truncated line never wraps, even on narrow terminals.
+const RESERVED_WIDTH: usize = 3;
+// Truncate short-mode items to this width even on very wide terminals: a
+// 130-column single line is hard to scan even when it technically fits, so
+// truncation shouldn't only kick in once text overflows the screen.
+const MAX_ITEM_WIDTH: usize = 100;
+
+// Enter/leave the terminal's alternate screen buffer (the same mechanism
+// vim/less/htop use). Inside it, the "screen" is exactly the visible
+// viewport with no scrollback, so a full clear-and-redraw is always safe —
+// no more reasoning about how many rows to rewind, which is what caused the
+// display corruption for long lists. Leaving it instantly restores whatever
+// was on the terminal before, with no cleanup bookkeeping needed.
+const ENTER_ALT_SCREEN: &str = "\x1b[?1049h";
+const LEAVE_ALT_SCREEN: &str = "\x1b[?1049l";
+const CLEAR_AND_HOME: &str = "\x1b[2J\x1b[H";
+
+/// A case-insensitive text matcher for the `/` filter (list) and `/` search
+/// (preview). Compiles the pattern as a regex when possible so power users
+/// get real regex support; falls back to a literal substring match when the
+/// pattern doesn't parse as one — most notably while the user is still
+/// mid-typing something like an unbalanced `(`, so the view never goes
+/// blank (or panics) just because a pattern isn't finished yet.
+enum Matcher {
+    Regex(Box<fancy_regex::Regex>),
+    Literal(String),
+}
+
+impl Matcher {
+    fn new(pattern: &str) -> Self {
+        match fancy_regex::RegexBuilder::new(pattern)
+            .case_insensitive(true)
+            .build()
+        {
+            Ok(re) => Matcher::Regex(Box::new(re)),
+            Err(_) => Matcher::Literal(pattern.to_lowercase()),
+        }
+    }
+
+    fn is_match(&self, text: &str) -> bool {
+        match self {
+            Matcher::Regex(re) => re.is_match(text).unwrap_or(false),
+            Matcher::Literal(needle) => text.to_lowercase().contains(needle.as_str()),
+        }
+    }
+}
+
+/// Builds the label shown for a gist. Gist descriptions conventionally
+/// already start with the primary filename (e.g. "hello.py - a script"), so
+/// filenames already present in the description are not repeated.
+fn build_item_text(gist: &GistInfo) -> String {
+    let desc = gist.description.as_deref().unwrap_or(DEFAULT_DESCRIPTION);
+    let desc_lower = desc.to_lowercase();
+
+    let extra_files: Vec<&str> = gist
+        .files
+        .iter()
+        .map(|f| f.filename.as_str())
+        .filter(|f| !desc_lower.contains(&f.to_lowercase()))
+        .collect();
+
+    if extra_files.is_empty() {
+        desc.to_string()
+    } else {
+        format!("{} - {}", desc, extra_files.join(", "))
+    }
+}
+
+/// Number of terminal rows `text` occupies when wrapped at column `width`.
+fn visual_row_count(text: &str, width: usize) -> usize {
+    if width == 0 {
+        return 1;
+    }
+    console::measure_text_width(text).div_ceil(width).max(1)
+}
+
+/// Renders one list row, truncating to fit `width` unless `full` is set.
+/// Truncation happens on the plain body text before styling is applied, so
+/// ANSI codes are never cut mid-sequence.
+fn render_line(text: &str, is_selected: bool, width: usize, full: bool) -> String {
+    let available = width.min(MAX_ITEM_WIDTH).saturating_sub(RESERVED_WIDTH);
+    let body = if full || available == 0 {
+        text.to_string()
+    } else {
+        console::truncate_str(text, available, "...").to_string()
+    };
+
+    if is_selected {
+        format!("{} {}", style("❯").cyan().bold(), style(body).cyan())
+    } else {
+        format!("  {}", body)
+    }
+}
+
+/// Rows available for item rows, after reserving one for the fixed header,
+/// one for the filter-status line (always shown, whether or not a filter is
+/// active, so the reserved budget never shifts as one gets typed), one for
+/// the position footer, and one safety margin row.
+fn page_capacity(term_rows: usize) -> usize {
+    term_rows.saturating_sub(4).max(1)
+}
+
+/// Picks a contiguous range of item indices to display, keeping `selected`
+/// visible without the total *rendered* row count (accounting for
+/// full-mode lines that wrap to more than one terminal row) exceeding
+/// `row_budget`. Grows outward from `selected` — mostly downward, filling
+/// upward with whatever budget remains — so item-count-based assumptions
+/// from short mode don't silently break once wrapped lines are wider than
+/// one row.
+fn visible_window(
+    items: &[String],
+    selected: usize,
+    full: bool,
+    width: usize,
+    row_budget: usize,
+) -> std::ops::Range<usize> {
+    if items.is_empty() {
+        return 0..0;
+    }
+    let row_budget = row_budget.max(1);
+
+    let row_cost = |i: usize| visual_row_count(&render_line(&items[i], false, width, full), width);
+
+    let mut start = selected;
+    let mut end = selected + 1;
+    let mut used = row_cost(selected).min(row_budget);
+
+    loop {
+        let mut grew = false;
+
+        if end < items.len() {
+            let cost = row_cost(end);
+            if used + cost <= row_budget {
+                used += cost;
+                end += 1;
+                grew = true;
+            }
+        }
+
+        if start > 0 {
+            let cost = row_cost(start - 1);
+            if used + cost <= row_budget {
+                used += cost;
+                start -= 1;
+                grew = true;
+            }
+        }
+
+        if !grew {
+            break;
+        }
+    }
+
+    start..end
+}
+
+/// Fetches one file's content, checking an in-session cache first, then the
+/// on-disk content cache, then falling back to the GitHub API — same
+/// fallback chain as `ScriptRunner::preview_content`. Successful API fetches
+/// are written back to the disk cache (best-effort) and the session cache,
+/// so re-opening the same preview during this picker session never refetches.
+fn fetch_file_content(
+    contents_dir: &Path,
+    gist_id: &str,
+    filename: &str,
+    session_cache: &mut HashMap<(String, String), String>,
+) -> Result<String> {
+    let key = (gist_id.to_string(), filename.to_string());
+    if let Some(cached) = session_cache.get(&key) {
+        return Ok(cached.clone());
+    }
+
+    let content_cache = ContentCache::new(contents_dir.to_path_buf());
+    let content = if content_cache.exists(gist_id, filename) {
+        match content_cache.read(gist_id, filename) {
+            Ok(c) => c,
+            Err(_) => GitHubApi::new().fetch_gist_content(gist_id, filename)?,
+        }
+    } else {
+        let fetched = GitHubApi::new().fetch_gist_content(gist_id, filename)?;
+        let _ = content_cache.write(gist_id, filename, &fetched);
+        fetched
+    };
+
+    session_cache.insert(key, content.clone());
+    Ok(content)
+}
+
+/// A gist's preview, flattened to individual display lines plus the
+/// absolute line index of each file's "--- filename ---" divider, so the
+/// viewer can pin the divider of whichever file is currently on screen.
+struct PreviewContent {
+    lines: Vec<String>,
+    dividers: Vec<usize>,
+}
+
+/// Builds the full set of display lines for a gist's preview — description,
+/// then each file's "--- filename ---" divider and syntax-highlighted
+/// content — as individual terminal lines so they can be scrolled. Each
+/// highlighted content line gets its own trailing reset code appended: the
+/// viewer only ever prints a sub-slice of this list, and without a
+/// per-line reset a color set by a line that's scrolled out of view could
+/// otherwise bleed into whatever is drawn after it.
+fn build_preview_lines(
+    gist: &GistInfo,
+    contents_dir: &Path,
+    session_cache: &mut HashMap<(String, String), String>,
+) -> PreviewContent {
+    let desc = gist.description.as_deref().unwrap_or(DEFAULT_DESCRIPTION);
+    let mut lines = vec![style(desc).cyan().bold().to_string(), String::new()];
+    let mut dividers = Vec::new();
+
+    for file in &gist.files {
+        dividers.push(lines.len());
+        lines.push(
+            style(format!("--- {} ---", file.filename))
+                .yellow()
+                .bold()
+                .to_string(),
+        );
+
+        match fetch_file_content(contents_dir, &gist.id, &file.filename, session_cache) {
+            Ok(content) => {
+                let highlighted = highlight_content(&file.filename, &content);
+                lines.extend(highlighted.split('\n').map(|line| format!("{line}\x1b[0m")));
+            }
+            Err(e) => {
+                lines.push(
+                    style(format!("  Failed to fetch content: {e}"))
+                        .red()
+                        .to_string(),
+                );
+            }
+        }
+        lines.push(String::new());
+    }
+
+    PreviewContent { lines, dividers }
+}
+
+/// The divider belonging to whichever file section `cursor` currently sits
+/// in: the last divider at or before `cursor`, so it's pinned only once the
+/// user has scrolled into (or past) that section, and "unsticks" again when
+/// scrolling back above it.
+fn active_divider(dividers: &[usize], cursor: usize) -> Option<usize> {
+    dividers.iter().rev().copied().find(|&d| d <= cursor)
+}
+
+/// Clamps a scroll position to a `[range_start, range_end)` sub-range of the
+/// content — used instead of always starting at 0 so the scrollable body can
+/// begin right after whatever's currently pinned (header + active divider).
+fn clamp_scroll(scroll: usize, viewport: usize, range_start: usize, range_end: usize) -> usize {
+    let max_scroll = range_end.saturating_sub(viewport).max(range_start);
+    scroll.clamp(range_start, max_scroll)
+}
+
+/// Moves the viewport's scroll offset just enough to keep `cursor` visible
+/// within `[range_start, range_end)`, following it past either edge (same
+/// idea as the list's `visible_window`, simplified since every preview line
+/// is exactly one row).
+fn follow_cursor(
+    scroll: usize,
+    cursor: usize,
+    viewport: usize,
+    range_start: usize,
+    range_end: usize,
+) -> usize {
+    let cursor = cursor.clamp(range_start, range_end.saturating_sub(1).max(range_start));
+    let scroll = if cursor < scroll {
+        cursor
+    } else if cursor >= scroll + viewport {
+        cursor + 1 - viewport
+    } else {
+        scroll
+    };
+    clamp_scroll(scroll, viewport, range_start, range_end)
+}
+
+/// Prefixes a preview line with a right-aligned line number and a leading
+/// `|` marker on the cursor's row, so the current position is visible
+/// alongside the line count. Truncates `content` to fit `width` (accounting
+/// for the gutter it just added): without this, a line wider than the
+/// terminal wraps, which both throws off the row-budget math that keeps the
+/// pinned header on screen and makes the wrapped remainder spill out from
+/// under the line-number column instead of staying aligned with it.
+fn render_preview_line(
+    line_no: usize,
+    content: &str,
+    is_cursor: bool,
+    gutter_width: usize,
+    width: usize,
+) -> String {
+    let marker = if is_cursor { "|" } else { " " };
+    let prefix_width = gutter_width + 3; // marker + space + gutter + space
+    let available = width.saturating_sub(prefix_width);
+    let body = if available == 0 {
+        content.to_string()
+    } else {
+        format!(
+            "{}\x1b[0m",
+            console::truncate_str(content, available, "...")
+        )
+    };
+    format!("{marker} {line_no:>gutter_width$} {body}")
+}
+
+/// Finds the next (or, going backward, previous) line whose plain text
+/// (ANSI codes stripped, since `lines` holds highlighted content) matches
+/// `matcher`, starting just past `from` and wrapping around the whole
+/// document. Returns `None` if nothing matches anywhere, including `from`
+/// itself once the search has wrapped all the way around.
+fn find_next_match(
+    lines: &[String],
+    matcher: &Matcher,
+    from: usize,
+    forward: bool,
+) -> Option<usize> {
+    let len = lines.len();
+    if len == 0 {
+        return None;
+    }
+    let mut i = from;
+    for _ in 0..len {
+        i = if forward {
+            (i + 1) % len
+        } else {
+            (i + len - 1) % len
+        };
+        if matcher.is_match(&console::strip_ansi_codes(&lines[i])) {
+            return Some(i);
+        }
+    }
+    None
+}
+
+/// Shows the full, syntax-highlighted content of `gist` as a scrollable,
+/// full-screen viewer with line numbers and a cursor marking the current
+/// line. The description and the current file's "--- filename ---" divider
+/// stay pinned at the top while the body beneath scrolls, like a frozen
+/// table header. A `/` search (regex supported, falls back to a literal
+/// substring match) jumps the cursor to the next match; `n`/`N` repeat it
+/// forward/backward. Runs entirely inside the alternate screen, so it's safe
+/// to display content of any length — each redraw is a full clear, so
+/// there's no row-count bookkeeping to get wrong regardless of how far the
+/// content scrolls. Returns once the user asks to go back (Space/Esc/Enter).
+fn show_preview(
+    term: &Term,
+    gist: &GistInfo,
+    contents_dir: &Path,
+    session_cache: &mut HashMap<(String, String), String>,
+) -> Result<()> {
+    let preview = build_preview_lines(gist, contents_dir, session_cache);
+    let lines = &preview.lines;
+    let gutter_width = lines.len().max(1).to_string().len();
+    // Description + blank line are always pinned; the active file divider
+    // joins them once the cursor scrolls into (or past) its section.
+    const HEADER_LEN: usize = 2;
+    let mut cursor = 0usize;
+    let mut scroll = HEADER_LEN;
+    let mut search_input = String::new();
+    let mut editing_search = false;
+    let mut last_search: Option<String> = None;
+
+    loop {
+        let (rows, width) = {
+            let (r, w) = term.size();
+            (r as usize, w as usize)
+        };
+
+        let divider = active_divider(&preview.dividers, cursor);
+        let pinned_count = HEADER_LEN + if divider.is_some() { 1 } else { 0 };
+        let body_start = divider.map(|d| d + 1).unwrap_or(HEADER_LEN);
+
+        // Reserve the pinned rows, one for the footer, one safety margin row.
+        let viewport = rows.saturating_sub(pinned_count + 2).max(1);
+        scroll = follow_cursor(scroll, cursor, viewport, body_start, lines.len());
+        let end = (scroll + viewport).min(lines.len());
+
+        term.write_str(CLEAR_AND_HOME).map_err(GistCacheError::Io)?;
+
+        for (i, line) in lines.iter().enumerate().take(HEADER_LEN) {
+            term.write_line(&render_preview_line(
+                i + 1,
+                line,
+                i == cursor,
+                gutter_width,
+                width,
+            ))
+            .map_err(GistCacheError::Io)?;
+        }
+        if let Some(d) = divider {
+            term.write_line(&render_preview_line(
+                d + 1,
+                &lines[d],
+                d == cursor,
+                gutter_width,
+                width,
+            ))
+            .map_err(GistCacheError::Io)?;
+        }
+
+        for (i, line) in lines.iter().enumerate().take(end).skip(scroll) {
+            term.write_line(&render_preview_line(
+                i + 1,
+                line,
+                i == cursor,
+                gutter_width,
+                width,
+            ))
+            .map_err(GistCacheError::Io)?;
+        }
+
+        let footer = if editing_search {
+            format!("/{search_input}_")
+        } else {
+            let search_hint = match &last_search {
+                Some(pattern) => format!(", /{pattern} n/N next/prev"),
+                None => String::new(),
+            };
+            format!(
+                "-- Line {}/{} -- ↑/↓ move, PgUp/PgDn Home/End jump, / search{search_hint}, Space/Esc/Enter back --",
+                cursor + 1,
+                lines.len()
+            )
+        };
+        // Truncate rather than let it wrap: a wrapped footer would consume
+        // an extra row we didn't budget for, which — on a short terminal —
+        // is exactly what pushes the pinned header off the top of the screen.
+        term.write_line(
+            &style(console::truncate_str(&footer, width, "").into_owned())
+                .dim()
+                .to_string(),
+        )
+        .map_err(GistCacheError::Io)?;
+
+        let key = term.read_key().map_err(GistCacheError::Io)?;
+        let last_line = lines.len().saturating_sub(1);
+
+        if editing_search {
+            match key {
+                Key::Enter => {
+                    let matcher = Matcher::new(&search_input);
+                    if let Some(pos) = find_next_match(lines, &matcher, cursor, true) {
+                        cursor = pos;
+                    }
+                    last_search = Some(std::mem::take(&mut search_input));
+                    editing_search = false;
+                }
+                Key::Escape => {
+                    editing_search = false;
+                    search_input.clear();
+                }
+                Key::Backspace => {
+                    search_input.pop();
+                }
+                Key::CtrlC => break,
+                Key::Char(c) => search_input.push(c),
+                _ => {}
+            }
+            continue;
+        }
+
+        match key {
+            Key::ArrowUp => cursor = cursor.saturating_sub(1),
+            Key::ArrowDown => cursor = (cursor + 1).min(last_line),
+            Key::PageUp => cursor = cursor.saturating_sub(viewport),
+            Key::PageDown => cursor = (cursor + viewport).min(last_line),
+            Key::Home => cursor = 0,
+            Key::End => cursor = last_line,
+            Key::Char('/') => editing_search = true,
+            Key::Char('n') => {
+                if let Some(pattern) = &last_search {
+                    let matcher = Matcher::new(pattern);
+                    if let Some(pos) = find_next_match(lines, &matcher, cursor, true) {
+                        cursor = pos;
+                    }
+                }
+            }
+            Key::Char('N') => {
+                if let Some(pattern) = &last_search {
+                    let matcher = Matcher::new(pattern);
+                    if let Some(pos) = find_next_match(lines, &matcher, cursor, false) {
+                        cursor = pos;
+                    }
+                }
+            }
+            Key::Char(' ') | Key::Char('\u{3000}') | Key::Escape | Key::Enter | Key::CtrlC => {
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+/// Interactive picker for search results, styled like dialoguer's Select but
+/// with a Tab toggle between truncated and full item text (long
+/// descriptions/filenames are abbreviated by default so the list stays
+/// scannable), a Space toggle to preview the selected gist's full,
+/// highlighted content without leaving the picker, and a `/` filter (regex
+/// supported, falls back to a literal substring match) to narrow the
+/// results further. Scrolls to keep the selection visible when there are
+/// more results than fit on screen. Runs inside the terminal's alternate
+/// screen buffer, so the picker (and any preview) never leaves artifacts in
+/// the shell's scrollback. Returns `Ok(None)` when the user cancels
+/// (Esc/Ctrl+C, or Esc a second time once an active filter has already been
+/// cleared).
+pub fn select(results: &[&GistInfo], contents_dir: &Path) -> Result<Option<usize>> {
+    let term = Term::stdout();
+    let items: Vec<String> = results.iter().map(|g| build_item_text(g)).collect();
+    let debug = std::env::var("GIST_CACHE_VERBOSE").is_ok();
+    let mut key_log: Vec<String> = Vec::new();
+    let mut content_cache: HashMap<(String, String), String> = HashMap::new();
+
+    term.write_str(ENTER_ALT_SCREEN)
+        .map_err(GistCacheError::Io)?;
+    term.hide_cursor().map_err(GistCacheError::Io)?;
+
+    let mut selected = 0usize;
+    let mut full = false;
+    let mut filter_input = String::new();
+    let mut editing_filter = false;
+
+    let outcome = loop {
+        let matcher = Matcher::new(&filter_input);
+        let visible: Vec<usize> = (0..items.len())
+            .filter(|&i| matcher.is_match(&items[i]))
+            .collect();
+        selected = if visible.is_empty() {
+            0
+        } else {
+            selected.min(visible.len() - 1)
+        };
+
+        let (rows, width) = {
+            let (r, w) = term.size();
+            (r as usize, w as usize)
+        };
+        let row_budget = page_capacity(rows);
+
+        term.write_str(CLEAR_AND_HOME).map_err(GistCacheError::Io)?;
+
+        term.write_line(&format!(
+            "{} Select a Gist {}",
+            style("?").cyan(),
+            style("(↑/↓ move, Space preview, Tab full/short, / filter, Enter select, Esc cancel)")
+                .dim()
+        ))
+        .map_err(GistCacheError::Io)?;
+
+        let filter_status = if editing_filter {
+            format!("Filter: /{filter_input}_")
+        } else if !filter_input.is_empty() {
+            format!(
+                "Filter: /{filter_input}  ({}/{} shown, / to edit, Esc to clear)",
+                visible.len(),
+                items.len()
+            )
+        } else {
+            "Filter: (press / to narrow results)".to_string()
+        };
+        term.write_line(&style(filter_status).dim().to_string())
+            .map_err(GistCacheError::Io)?;
+
+        if visible.is_empty() {
+            term.write_line(&style("  -- No matches --").red().to_string())
+                .map_err(GistCacheError::Io)?;
+        } else {
+            let filtered_items: Vec<String> = visible.iter().map(|&i| items[i].clone()).collect();
+            let window = visible_window(&filtered_items, selected, full, width, row_budget);
+            for i in window {
+                term.write_line(&render_line(&filtered_items[i], i == selected, width, full))
+                    .map_err(GistCacheError::Io)?;
+            }
+        }
+
+        term.write_line(
+            &style(format!(
+                "  [{}/{}] (Tab: {})",
+                if visible.is_empty() { 0 } else { selected + 1 },
+                visible.len(),
+                if full { "full" } else { "short" }
+            ))
+            .dim()
+            .to_string(),
+        )
+        .map_err(GistCacheError::Io)?;
+
+        let key = match term.read_key() {
+            Ok(key) => key,
+            Err(e) => {
+                term.show_cursor().ok();
+                term.write_str(LEAVE_ALT_SCREEN).ok();
+                return Err(GistCacheError::Io(e));
+            }
+        };
+
+        if debug {
+            key_log.push(format!("{:?}", key));
+        }
+
+        if editing_filter {
+            match key {
+                Key::Enter => {
+                    if let Some(&i) = visible.get(selected) {
+                        break Some(i);
+                    }
+                }
+                Key::Escape => editing_filter = false,
+                Key::Backspace => {
+                    filter_input.pop();
+                }
+                Key::ArrowUp if !visible.is_empty() => {
+                    selected = if selected == 0 {
+                        visible.len() - 1
+                    } else {
+                        selected - 1
+                    };
+                }
+                Key::ArrowDown if !visible.is_empty() => {
+                    selected = (selected + 1) % visible.len();
+                }
+                Key::Tab => full = !full,
+                Key::CtrlC => break None,
+                Key::Char(c) => filter_input.push(c),
+                _ => {}
+            }
+        } else {
+            match key {
+                Key::Char('/') => editing_filter = true,
+                Key::ArrowUp if !visible.is_empty() => {
+                    selected = if selected == 0 {
+                        visible.len() - 1
+                    } else {
+                        selected - 1
+                    };
+                }
+                Key::ArrowDown if !visible.is_empty() => {
+                    selected = (selected + 1) % visible.len();
+                }
+                Key::Tab => full = !full,
+                // '\u{3000}' (IDEOGRAPHIC SPACE) is what some Japanese IMEs
+                // send for the space bar even outside of text conversion, so
+                // both are accepted as the preview trigger.
+                Key::Char(' ') | Key::Char('\u{3000}') if !visible.is_empty() => {
+                    // Preview errors (e.g. a failed API fetch) are shown
+                    // inline by show_preview itself; nothing more to do
+                    // here either way.
+                    let _ = show_preview(
+                        &term,
+                        results[visible[selected]],
+                        contents_dir,
+                        &mut content_cache,
+                    );
+                }
+                Key::Enter => {
+                    if let Some(&i) = visible.get(selected) {
+                        break Some(i);
+                    }
+                }
+                Key::Escape => {
+                    if filter_input.is_empty() {
+                        break None;
+                    }
+                    filter_input.clear();
+                }
+                Key::CtrlC => break None,
+                _ => {}
+            }
+        }
+    };
+
+    term.show_cursor().ok();
+    term.write_str(LEAVE_ALT_SCREEN)
+        .map_err(GistCacheError::Io)?;
+
+    if debug {
+        eprintln!("[gist-cache-rs] keys received: {}", key_log.join(", "));
+    }
+
+    if let Some(index) = outcome {
+        println!(
+            "{} Select a Gist {} {}",
+            style("✔").green(),
+            style("·").dim(),
+            items[index]
+        );
+    }
+
+    Ok(outcome)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::types::GistFile;
+    use chrono::Utc;
+
+    fn gist(desc: Option<&str>, filenames: Vec<&str>) -> GistInfo {
+        GistInfo {
+            id: "abc123".to_string(),
+            description: desc.map(|s| s.to_string()),
+            files: filenames
+                .into_iter()
+                .map(|name| GistFile {
+                    filename: name.to_string(),
+                    language: None,
+                    size: 100,
+                })
+                .collect(),
+            updated_at: Utc::now(),
+            public: true,
+            html_url: "https://gist.github.com/abc123".to_string(),
+        }
+    }
+
+    #[test]
+    fn matcher_does_plain_case_insensitive_substring_matching() {
+        let m = Matcher::new("Hello");
+        assert!(m.is_match("say hello world"));
+        assert!(!m.is_match("goodbye world"));
+    }
+
+    #[test]
+    fn matcher_supports_regex_patterns() {
+        let m = Matcher::new(r"^test_.*\.py$");
+        assert!(m.is_match("test_python.py"));
+        assert!(!m.is_match("test_python.rb"));
+        assert!(!m.is_match("my_test_python.py"));
+    }
+
+    #[test]
+    fn matcher_empty_pattern_matches_everything() {
+        let m = Matcher::new("");
+        assert!(m.is_match("anything"));
+        assert!(m.is_match(""));
+    }
+
+    #[test]
+    fn matcher_falls_back_to_literal_on_invalid_regex() {
+        // An unbalanced group is invalid regex syntax (e.g. mid-typing);
+        // it must still work as a literal substring match rather than
+        // making every item disappear from the list.
+        let m = Matcher::new("test_(unclosed");
+        assert!(m.is_match("test_(unclosed_group.py"));
+        assert!(!m.is_match("unrelated.py"));
+    }
+
+    #[test]
+    fn find_next_match_wraps_forward() {
+        let lines = vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()];
+        let m = Matcher::new("alpha");
+        // Starting past the only match, searching forward wraps around.
+        assert_eq!(find_next_match(&lines, &m, 1, true), Some(0));
+    }
+
+    #[test]
+    fn find_next_match_wraps_backward() {
+        let lines = vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()];
+        let m = Matcher::new("gamma");
+        assert_eq!(find_next_match(&lines, &m, 0, false), Some(2));
+    }
+
+    #[test]
+    fn find_next_match_returns_none_when_nothing_matches() {
+        let lines = vec!["alpha".to_string(), "beta".to_string()];
+        let m = Matcher::new("zzz");
+        assert_eq!(find_next_match(&lines, &m, 0, true), None);
+    }
+
+    #[test]
+    fn find_next_match_ignores_ansi_codes_in_the_line() {
+        let lines = vec![format!("{}needle{}", "\x1b[31m", "\x1b[0m")];
+        let m = Matcher::new("needle");
+        assert_eq!(find_next_match(&lines, &m, 0, true), Some(0));
+    }
+
+    #[test]
+    fn build_item_text_omits_filename_already_in_description() {
+        let g = gist(
+            Some("hello_args.py - Python引数テストスクリプト #python #test"),
+            vec!["hello_args.py"],
+        );
+        assert_eq!(
+            build_item_text(&g),
+            "hello_args.py - Python引数テストスクリプト #python #test"
+        );
+    }
+
+    #[test]
+    fn build_item_text_appends_filenames_not_in_description() {
+        let g = gist(Some("A helper script"), vec!["helper.sh"]);
+        assert_eq!(build_item_text(&g), "A helper script - helper.sh");
+    }
+
+    #[test]
+    fn build_item_text_appends_only_missing_files_from_multiple() {
+        let g = gist(Some("main.py - entry point"), vec!["main.py", "utils.py"]);
+        assert_eq!(build_item_text(&g), "main.py - entry point - utils.py");
+    }
+
+    #[test]
+    fn build_item_text_uses_default_when_no_description() {
+        let g = gist(None, vec!["script.sh"]);
+        assert_eq!(build_item_text(&g), "No description - script.sh");
+    }
+
+    #[test]
+    fn visual_row_count_wraps_at_width() {
+        assert_eq!(visual_row_count("hello", 80), 1);
+        assert_eq!(visual_row_count(&"x".repeat(85), 80), 2);
+        assert_eq!(visual_row_count("", 80), 1);
+    }
+
+    #[test]
+    fn visual_row_count_handles_zero_width() {
+        assert_eq!(visual_row_count("hello", 0), 1);
+    }
+
+    #[test]
+    fn render_line_truncates_when_not_full() {
+        let text = "a".repeat(100);
+        let line = render_line(&text, false, 20, false);
+        assert!(console::measure_text_width(&line) <= 20);
+        assert!(line.contains("..."));
+    }
+
+    #[test]
+    fn render_line_truncates_long_text_even_on_a_wide_terminal() {
+        // A single long line is hard to scan even when the terminal is wide
+        // enough to fit it without wrapping, so short mode caps at
+        // MAX_ITEM_WIDTH regardless of the actual terminal width.
+        let text = "a".repeat(200);
+        let line = render_line(&text, false, 300, false);
+        assert!(console::measure_text_width(&line) <= MAX_ITEM_WIDTH);
+        assert!(line.contains("..."));
+    }
+
+    #[test]
+    fn render_line_shows_everything_when_full() {
+        let text = "a".repeat(100);
+        let line = render_line(&text, false, 20, true);
+        assert!(!line.contains("..."));
+        assert!(line.ends_with(&text));
+    }
+
+    #[test]
+    fn render_line_marks_selected_item() {
+        let line = render_line("item", true, 80, false);
+        assert!(line.contains('❯'));
+    }
+
+    #[test]
+    fn page_capacity_reserves_header_footer_and_margin() {
+        assert_eq!(page_capacity(24), 20);
+        assert_eq!(page_capacity(3), 1); // never collapses to zero
+        assert_eq!(page_capacity(0), 1);
+    }
+
+    #[test]
+    fn clamp_scroll_keeps_position_within_bounds() {
+        assert_eq!(clamp_scroll(5, 10, 0, 100), 5); // within range, unchanged
+        assert_eq!(clamp_scroll(95, 10, 0, 100), 90); // clamps to the last full page
+        assert_eq!(clamp_scroll(5, 20, 0, 10), 0); // content fits entirely: no scroll
+        assert_eq!(clamp_scroll(0, 5, 0, 0), 0); // empty content
+    }
+
+    #[test]
+    fn clamp_scroll_never_goes_below_range_start() {
+        // Sub-range starting at 4 (e.g. body right after a pinned divider).
+        assert_eq!(clamp_scroll(0, 3, 4, 20), 4);
+        assert_eq!(clamp_scroll(2, 3, 4, 20), 4);
+    }
+
+    #[test]
+    fn follow_cursor_scrolls_down_past_bottom_edge() {
+        // Viewport [0, 3), cursor moves to line 5: viewport must include it.
+        let scroll = follow_cursor(0, 5, 3, 0, 10);
+        assert_eq!(scroll, 3);
+    }
+
+    #[test]
+    fn follow_cursor_scrolls_up_past_top_edge() {
+        let scroll = follow_cursor(5, 2, 3, 0, 10);
+        assert_eq!(scroll, 2);
+    }
+
+    #[test]
+    fn follow_cursor_keeps_scroll_when_cursor_stays_in_view() {
+        let scroll = follow_cursor(2, 3, 3, 0, 10);
+        assert_eq!(scroll, 2);
+    }
+
+    #[test]
+    fn follow_cursor_never_scrolls_past_the_end() {
+        let scroll = follow_cursor(0, 9, 3, 0, 10);
+        assert_eq!(scroll, 7); // window becomes [7, 8, 9]
+    }
+
+    #[test]
+    fn follow_cursor_respects_a_sub_range_start() {
+        // Cursor is inside the pinned area (before range_start): the body
+        // viewport should still start at range_start, not run before it.
+        let scroll = follow_cursor(10, 1, 3, 4, 20);
+        assert_eq!(scroll, 4);
+    }
+
+    #[test]
+    fn active_divider_picks_the_last_divider_at_or_before_cursor() {
+        let dividers = [2usize, 10, 18];
+        assert_eq!(active_divider(&dividers, 0), None); // still in the header
+        assert_eq!(active_divider(&dividers, 2), Some(2)); // on the divider itself
+        assert_eq!(active_divider(&dividers, 9), Some(2));
+        assert_eq!(active_divider(&dividers, 10), Some(10));
+        assert_eq!(active_divider(&dividers, 25), Some(18));
+    }
+
+    #[test]
+    fn render_preview_line_marks_only_the_cursor_row() {
+        let cursor_line = render_preview_line(3, "def main():", true, 3, 80);
+        let other_line = render_preview_line(2, "import sys", false, 3, 80);
+        assert!(cursor_line.starts_with('|'));
+        assert!(other_line.starts_with(' '));
+        assert!(cursor_line.contains("  3"));
+        assert!(cursor_line.contains("def main():"));
+    }
+
+    #[test]
+    fn render_preview_line_truncates_to_fit_the_terminal_width() {
+        // A narrow terminal must never let the content push the line past
+        // `width`: a wrapped line breaks the row-budget math that keeps the
+        // pinned header on screen.
+        let long_content = "x".repeat(200);
+        let line = render_preview_line(1, &long_content, false, 3, 20);
+        assert!(console::measure_text_width(&line) <= 20);
+        assert!(line.contains("..."));
+    }
+
+    #[test]
+    fn render_preview_line_keeps_short_content_untruncated() {
+        let line = render_preview_line(1, "short", false, 3, 80);
+        assert!(line.contains("short"));
+        assert!(!line.contains("..."));
+    }
+
+    fn make_items(n: usize) -> Vec<String> {
+        (0..n).map(|i| format!("item{i}")).collect()
+    }
+
+    fn window_row_cost(
+        items: &[String],
+        window: std::ops::Range<usize>,
+        full: bool,
+        width: usize,
+    ) -> usize {
+        window
+            .map(|i| visual_row_count(&render_line(&items[i], false, width, full), width))
+            .sum()
+    }
+
+    #[test]
+    fn visible_window_includes_selection_and_respects_row_budget() {
+        let items = make_items(10);
+        let window = visible_window(&items, 5, false, 80, 3);
+        assert!(window.contains(&5));
+        assert!(window_row_cost(&items, window, false, 80) <= 3);
+    }
+
+    #[test]
+    fn visible_window_does_not_run_past_start_of_list() {
+        let items = make_items(10);
+        let window = visible_window(&items, 0, false, 80, 3);
+        assert_eq!(window.start, 0);
+    }
+
+    #[test]
+    fn visible_window_does_not_run_past_end_of_list() {
+        let items = make_items(10);
+        let window = visible_window(&items, 9, false, 80, 3);
+        assert_eq!(window.end, 10);
+    }
+
+    #[test]
+    fn visible_window_shows_everything_when_list_fits_budget() {
+        let items = make_items(5);
+        let window = visible_window(&items, 2, false, 80, 10);
+        assert_eq!(window, 0..5);
+    }
+
+    #[test]
+    fn visible_window_handles_empty_list() {
+        let items: Vec<String> = Vec::new();
+        assert_eq!(visible_window(&items, 0, false, 80, 10), 0..0);
+    }
+
+    #[test]
+    fn visible_window_accounts_for_wrapped_rows_in_full_mode() {
+        // Each item wraps to multiple rows once rendered in full mode on a
+        // narrow terminal, so an item-count-based window would blow the row
+        // budget; the window must shrink to compensate.
+        let items: Vec<String> = (0..10).map(|_| "a".repeat(50)).collect();
+        let width = 20;
+        let window = visible_window(&items, 5, true, width, 6);
+        assert!(window.contains(&5));
+        assert!(window_row_cost(&items, window, true, width) <= 6);
+    }
+}

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,3 +1,4 @@
+pub mod interactive;
 pub mod query;
 
 pub use query::{SearchMode, SearchQuery, select_from_results};

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -1,5 +1,6 @@
 use crate::cache::types::GistInfo;
 use crate::error::{GistCacheError, Result};
+use std::path::Path;
 
 #[derive(Debug, Clone)]
 pub enum SearchMode {
@@ -98,9 +99,10 @@ impl SearchQuery {
     }
 }
 
-pub fn select_from_results<'a>(results: &[&'a GistInfo]) -> Result<&'a GistInfo> {
-    use dialoguer::{Select, theme::ColorfulTheme};
-
+pub fn select_from_results<'a>(
+    results: &[&'a GistInfo],
+    contents_dir: &Path,
+) -> Result<&'a GistInfo> {
     if results.is_empty() {
         return Err(GistCacheError::NoSearchResults("".to_string()));
     }
@@ -109,28 +111,9 @@ pub fn select_from_results<'a>(results: &[&'a GistInfo]) -> Result<&'a GistInfo>
         return Ok(results[0]);
     }
 
-    let default_desc = "No description".to_string();
-
-    // Create display items: "description - files"
-    let items: Vec<String> = results
-        .iter()
-        .map(|gist| {
-            let desc = gist.description.as_ref().unwrap_or(&default_desc);
-            let files: Vec<_> = gist.files.iter().map(|f| f.filename.as_str()).collect();
-            format!("{} - {}", desc, files.join(", "))
-        })
-        .collect();
-
     println!("\nMultiple Gists found:\n");
 
-    let selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select a Gist")
-        .items(&items)
-        .default(0)
-        .interact_opt()
-        .map_err(|e| GistCacheError::Io(std::io::Error::other(e)))?;
-
-    match selection {
+    match crate::search::interactive::select(results, contents_dir)? {
         Some(index) => Ok(results[index]),
         None => Err(GistCacheError::InvalidSelection),
     }
@@ -269,7 +252,7 @@ mod tests {
     #[test]
     fn test_select_from_empty_results() {
         let results: Vec<&GistInfo> = vec![];
-        let error = select_from_results(&results).unwrap_err();
+        let error = select_from_results(&results, Path::new("/tmp/contents")).unwrap_err();
         assert!(matches!(error, GistCacheError::NoSearchResults(_)));
     }
 
@@ -277,7 +260,7 @@ mod tests {
     fn test_select_from_single_result() {
         let gist = create_test_gist("abc123", Some("Test"), vec!["file.rs"]);
         let results = vec![&gist];
-        let selected = select_from_results(&results).unwrap();
+        let selected = select_from_results(&results, Path::new("/tmp/contents")).unwrap();
         assert_eq!(selected.id, "abc123");
     }
 


### PR DESCRIPTION
## Summary

- Replaced `dialoguer::Select` with a custom `console`-based picker running in the terminal's alternate screen buffer, fixing the display corruption a plain redraw hit once results exceeded the terminal height
- List items are deduplicated (no repeated filename when the description already starts with it) and truncated to a readable width, with `Tab` to show the full text
- `Space` opens an in-picker, syntax-highlighted content preview (via `syntect` + `two-face`) with line numbers, a cursor indicator, sticky description/file headers, and its own scrolling — no need to re-select/re-fetch to look again
- `/` filters the selection list; `/` inside the preview searches its content and jumps to matches (`n`/`N` for next/previous) — both support regex via `fancy-regex`, falling back to a literal substring match for invalid patterns
- `--preview` output is now syntax-highlighted

Closes #74

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (185 lib tests + integration tests, run with `--test-threads=1` to avoid an unrelated pre-existing Windows stdout-pipe flake in the test harness)
- [x] Manually verified in a real Windows terminal across several iterations: list truncation/dedup, Tab full/short toggle, scroll-follow on long result sets, `Space` preview with line numbers/cursor/sticky headers, narrow-terminal behavior, `/` filter (plain + regex) on the list, `/` search + `n`/`N` in the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)